### PR TITLE
making the declarative mapper work in Chrome

### DIFF
--- a/src/createMapper.ts
+++ b/src/createMapper.ts
@@ -55,8 +55,8 @@ export default function createMapper<TSource, TResult>(map: TRootMapping, option
 
 	return (document: TSource): TResult | undefined => {
 
-		sandbox.$input = document;
-		sandbox.$result = undefined;
+		context.$input = document;
+		context.$result = undefined;
 
 		if (extensionNames) {
 			const conflictingKey = Object.keys(document).find(inputKey => extensionNames.includes(inputKey));
@@ -66,6 +66,6 @@ export default function createMapper<TSource, TResult>(map: TRootMapping, option
 
 		script.runInContext(context);
 
-		return sandbox.$result;
+		return context.$result;
 	};
 };


### PR DESCRIPTION
In node it works to set the variables on the sandbox.
But for this to work in Chrome it needs to set them on the actual context.

All tests are passing, it looks like this was the initial intent.